### PR TITLE
Add Browser Cookies Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Here's a brief overview of the available options:
 | Thumbnail | No thumbnails | No thumbnails will be downloaded |
 | Thumbnail | Embedded thumbnails | Thumbnails will be downloaded and embedded inside the media file |
 | Thumbnail | Standalone thumbnails | Thumbnails will be downloaded and stored as a separate file alongside the media file. You can specify the format of the thumbnail with the dropdown menu |
+| General | Use Cookies from Browser | If checked, it will attempt to grab your existing cookies from the selected browser. Use this option if downloading YouTube membership content (assuming you've paid for it, obviously) | 
 | Video | Convert Video | If checked, it will attempt to convert your video to the format selected in the dropdown box |
-| Video | Preferred quality | Selecting a specific resolution (like 1080p) will cause yt-dlp to try and grab a 1080p version. If unavailable, it will grab the next best quality option |
+| Video | Preferred quality | Selecting best will give you the best video & best audio merged together. Selecting a specific resolution (like 1080p) will cause yt-dlp to try and grab a 1080p version. If unavailable, it will grab the next best quality option |
 | Audio | Keep audio only | If checked, then only the audio will be downloaded. You can optionally select a desired format for the output  |
 | Audio | Bitrate in kbps | You can specify your desired bitrate. For mp3, either VBR (0, 1, 2, etc) or CBR (128, 192, 320, etc) values are accepted |
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's a brief overview of the available options:
 <br><br>
 
 # Future Features & TODOs
-- Add a console output window inside of the UI to monitor progress of the downloads
+- ~~Add a console output window inside of the UI to monitor progress of the downloads~~ too hard lol
 - Add a separate tab to set/update your ffmpeg directory
 - Add the ability to set a default download directory instead of asking every time
 - Improve preferred quality selection logic

--- a/source/yt-dlp_gui.py
+++ b/source/yt-dlp_gui.py
@@ -51,35 +51,24 @@ class MainWindow(QWidget):
         # Check for ffmpeg installation
         self.ffmpeg_directory = self.set_ffmpeg_directory()
 
-        # Widgets - create
-        self.url_input_label = QLabel("Paste URLs, one per line:")
-        self.url_input = QPlainTextEdit()
-        self.thumbnail_button_group = QButtonGroup(
-            buttonClicked=self.change_thumbnail_checkbox_state
-        )
+        # Thumbnail option widgets
         self.thumbnail_radio_box = QGroupBox("Thumbnail Options")
         self.thumbnail_embed_radio = QRadioButton("Embedded thumbnails")
         self.thumbnail_standalone_radio = QRadioButton("Standalone thumbnails")
         self.thumbnail_none_radio = QRadioButton("No thumbnails")
         self.thumbnail_format_dropdown = QComboBox()
-        self.video_options_box = QGroupBox("Video Options")
-        self.video_convert_checkbox = QCheckBox("Convert video")
-        self.video_format_dropdown = QComboBox()
-        self.video_quality_label = QLabel("Preferred quality")
-        self.video_quality_dropdown = QComboBox()
-        self.audio_options_box = QGroupBox("Audio Options")
-        self.strip_audio_checkbox = QCheckBox("Keep audio only")
-        self.audio_format_label = QLabel("Convert audio file to:")
-        self.audio_format_dropdown = QComboBox()
-        self.audio_bitrate_checkbox = QLabel("Bitrate in kbps (optional)")
-        self.audio_bitrate_input = QLineEdit()
-        self.confirm_button = QPushButton("Start Download", clicked=self.download)
-        self.output_check_button = QPushButton(
-            "Check Output", clicked=self.output_check
-        )
-        self.output_check_text = QPlainTextEdit()
 
-        # Widgets - logical grouping
+        self.thumbnail_embed_radio.setChecked(True)
+        self.thumbnail_format_dropdown.addItems(MEDIA_EXTENSIONS.thumbnails)
+        self.thumbnail_format_dropdown.hide()
+        self.thumbnail_embed_radio.setToolTip("Embed thumbnails in the media file")
+        self.thumbnail_standalone_radio.setToolTip(
+            "Save thumbnails as standalone image files"
+        )
+
+        self.thumbnail_button_group = QButtonGroup(
+            buttonClicked=self.change_thumbnail_checkbox_state
+        )
         self.thumbnail_button_group.addButton(self.thumbnail_embed_radio)
         self.thumbnail_button_group.addButton(self.thumbnail_standalone_radio)
         self.thumbnail_button_group.addButton(self.thumbnail_none_radio)
@@ -91,12 +80,60 @@ class MainWindow(QWidget):
         radio_box_layout.addWidget(self.thumbnail_format_dropdown, 2, 1)
         self.thumbnail_radio_box.setLayout(radio_box_layout)
 
+
+        # General options widgets
+        self.general_options_box = (QGroupBox("General Options"))
+        self.cookies_check_box = QCheckBox("Use Cookies from Browser")
+        self.cookies_browser_dropdown = QComboBox()
+
+        self.cookies_browser_dropdown.addItems(
+            ["", "brave", "chrome", "chromium", "edge", "firefox", "opera", "safari", "vivaldi"]
+        )
+        self.cookies_check_box.setToolTip(
+            "Use cookies from your browser. Useful for retrieving membership-gated content on YouTube."
+        )
+
+        general_options_box_layout = QGridLayout()
+        general_options_box_layout.addWidget(self.cookies_check_box, 0, 0)
+        general_options_box_layout.addWidget(self.cookies_browser_dropdown, 0, 1)
+        self.general_options_box.setLayout(general_options_box_layout)
+
+
+        # Video option widgets
+        self.video_options_box = QGroupBox("Video Options")
+        self.video_convert_checkbox = QCheckBox("Convert video")
+        self.video_format_dropdown = QComboBox()
+        self.video_quality_label = QLabel("Preferred quality")
+        self.video_quality_dropdown = QComboBox()
+
+        self.video_format_dropdown.addItem("")
+        self.video_format_dropdown.addItems(MEDIA_EXTENSIONS.common_video)
+        self.video_quality_dropdown.addItems(
+            ["best", "1080p", "720p", "480p", "360p", "240p", "worst"]
+        )
+        self.video_quality_label.setToolTip(
+            "Will attempt to download video at specified quality. If unavailable, it will grab the next best option"
+        )
+
         video_box_layout = QGridLayout()
         video_box_layout.addWidget(self.video_convert_checkbox, 0, 0)
         video_box_layout.addWidget(self.video_format_dropdown, 0, 1)
         video_box_layout.addWidget(self.video_quality_label, 1, 0)
         video_box_layout.addWidget(self.video_quality_dropdown, 1, 1)
         self.video_options_box.setLayout(video_box_layout)
+
+
+        # Audio option widgets
+        self.audio_options_box = QGroupBox("Audio Options")
+        self.strip_audio_checkbox = QCheckBox("Keep audio only")
+        self.audio_format_label = QLabel("Convert audio file to:")
+        self.audio_format_dropdown = QComboBox()
+        self.audio_bitrate_checkbox = QLabel("Bitrate in kbps (optional)")
+        self.audio_bitrate_input = QLineEdit()
+
+        self.audio_format_dropdown.addItem("source format")
+        self.audio_format_dropdown.addItems(MEDIA_EXTENSIONS.common_audio)
+        self.strip_audio_checkbox.setToolTip("Saves only the audio, deletes the video")
 
         audio_box_layout = QGridLayout()
         audio_box_layout.addWidget(self.strip_audio_checkbox, 0, 0)
@@ -105,14 +142,28 @@ class MainWindow(QWidget):
         audio_box_layout.addWidget(self.audio_bitrate_input, 1, 1)
         self.audio_options_box.setLayout(audio_box_layout)
 
-        all_options_layout = (
-            QGridLayout()
-        )  # (widget, row, col, row_span, col_span, alignment)
-        all_options_layout.setColumnMinimumWidth(
-            1, 15
-        )  # Adds blank space between columns 0 & 2
+
+        # All other widgets
+        self.url_input_label = QLabel("Paste URLs, one per line:")
+        self.url_input = QPlainTextEdit()
+
+        self.confirm_button = QPushButton("Start Download", clicked=self.download)
+
+
+        # Debug widgets
+        self.output_check_button = QPushButton(
+            "Check Output", clicked=self.output_check
+        )
+        self.output_check_text = QPlainTextEdit()
+        self.output_check_text.setReadOnly(True)
+
+
+        # (widget, row, col, row_span, col_span, alignment)
+        all_options_layout = QGridLayout()  
+        all_options_layout.setColumnMinimumWidth(1, 15) # Add blank space
         all_options_layout.setRowMinimumHeight(4, 15)
         all_options_layout.addWidget(self.thumbnail_radio_box, 0, 0, 4, 1)
+        all_options_layout.addWidget(self.general_options_box, 0, 2, 4, 1)
         all_options_layout.addWidget(self.video_options_box, 5, 0, 4, 1)
         all_options_layout.addWidget(self.audio_options_box, 5, 2, 4, 1)
 
@@ -123,31 +174,11 @@ class MainWindow(QWidget):
         main_layout.addItem(QSpacerItem(default_width, 60))
         main_layout.addWidget(self.confirm_button)
 
+
         if DEBUG:
             main_layout.addWidget(self.output_check_button)
             main_layout.addWidget(self.output_check_text)
 
-        # Widgets - configure and set defaults
-        self.output_check_text.setReadOnly(True)
-        self.thumbnail_standalone_radio.setChecked(True)
-        self.thumbnail_format_dropdown.addItems(MEDIA_EXTENSIONS.thumbnails)
-        self.video_format_dropdown.addItem("")
-        self.video_format_dropdown.addItems(MEDIA_EXTENSIONS.common_video)
-        self.video_quality_dropdown.addItems(
-            ["best", "1080p", "720p", "480p", "360p", "240p", "worst"]
-        )
-        self.audio_format_dropdown.addItem("source format")
-        self.audio_format_dropdown.addItems(MEDIA_EXTENSIONS.common_audio)
-
-        # Widgets - set tooltips
-        self.strip_audio_checkbox.setToolTip("Saves only the audio, deletes the video")
-        self.thumbnail_embed_radio.setToolTip("Embed thumbnails in the media file")
-        self.thumbnail_standalone_radio.setToolTip(
-            "Save thumbnails as standalone image files"
-        )
-        self.video_quality_label.setToolTip(
-            "Will attempt to download video at specified quality. If unavailable, it will grab the next best option"
-        )
 
     def change_thumbnail_checkbox_state(self):
         if self.thumbnail_standalone_radio.isChecked():
@@ -155,7 +186,7 @@ class MainWindow(QWidget):
         else:
             self.thumbnail_format_dropdown.hide()
 
-    # Dry run, doesn't actually download anything
+    # DEBUG - Dry run, doesn't actually download anything
     def output_check(self):
         self.output_check_text.clear()
         self.set_output_directory()
@@ -165,7 +196,7 @@ class MainWindow(QWidget):
         if "ffmpeg_directory" not in self.app_config:
             self.pop_up_box = QMessageBox()
             self.pop_up_box.setText(
-                "Please select the 'bin' folder containing your ffmpeg executable"
+                "Please select your ffmpeg executable"
             )
             self.pop_up_box.exec()
 
@@ -195,6 +226,9 @@ class MainWindow(QWidget):
             "ffmpeg_location": self.ffmpeg_directory,
             "postprocessors": [],
         }
+
+        if self.cookies_check_box.isChecked():
+            config["cookiesfrombrowser"] = (self.cookies_browser_dropdown.currentText(),)
 
         video_quality = self.video_quality_dropdown.currentText()
 
@@ -273,9 +307,17 @@ class MainWindow(QWidget):
         config = self.create_ytdlp_config()
 
         # Execute the download
-        with YoutubeDL(config) as ydl:
-            error_code = ydl.download(self.urls)
+        error_list = []
+        for url in self.urls:
+            try:
+                with YoutubeDL(config) as ydl:
+                    result = ydl.download(url)
+            except Exception as e:
+                error_list.append(e)
 
+        if len(error_list) != 0:
+            for error in error_list:
+                print(error)
         print("Done!")
 
 

--- a/source/yt-dlp_gui.py
+++ b/source/yt-dlp_gui.py
@@ -86,6 +86,7 @@ class MainWindow(QWidget):
         self.cookies_check_box = QCheckBox("Use Cookies from Browser")
         self.cookies_browser_dropdown = QComboBox()
 
+        # Would prefer a list maintained by yt-dlp, similar to ffmpeg codecs
         self.cookies_browser_dropdown.addItems(
             ["", "brave", "chrome", "chromium", "edge", "firefox", "opera", "safari", "vivaldi"]
         )


### PR DESCRIPTION
Adds ability to use browser cookies (with browser selection). This is useful for downloading/archiving membership content that you've paid for. Also reorganizes widget creation & settings by category (aka all the thumbnail widgets are created and configured in the same block).