### PR TITLE
Add Settings Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Here's a brief overview of the available options:
 
 | Category | Option | Description |
 |---|---|---|
+| General | Use Cookies from Browser | If checked, it will attempt to grab your existing cookies from the selected browser. Use this option if downloading YouTube membership content (assuming you've paid for it, obviously) | 
 | Thumbnail | No thumbnails | No thumbnails will be downloaded |
 | Thumbnail | Embedded thumbnails | Thumbnails will be downloaded and embedded inside the media file |
 | Thumbnail | Standalone thumbnails | Thumbnails will be downloaded and stored as a separate file alongside the media file. You can specify the format of the thumbnail with the dropdown menu |
-| General | Use Cookies from Browser | If checked, it will attempt to grab your existing cookies from the selected browser. Use this option if downloading YouTube membership content (assuming you've paid for it, obviously) | 
 | Video | Convert Video | If checked, it will attempt to convert your video to the format selected in the dropdown box |
 | Video | Preferred quality | Selecting best will give you the best video & best audio merged together. Selecting a specific resolution (like 1080p) will cause yt-dlp to try and grab a 1080p version. If unavailable, it will grab the next best quality option |
 | Audio | Keep audio only | If checked, then only the audio will be downloaded. You can optionally select a desired format for the output  |
@@ -50,7 +50,7 @@ Here's a brief overview of the available options:
 
 # Future Features & TODOs
 - ~~Add a console output window inside of the UI to monitor progress of the downloads~~ too hard lol
-- Add a separate tab to set/update your ffmpeg directory
-- Add the ability to set a default download directory instead of asking every time
+- ~~Add a separate tab to set/update your ffmpeg directory~~
+- ~~Add the ability to set a default download directory instead of asking every time~~
 - Improve preferred quality selection logic
 - Address cross-platform theming (dark theme only works for Windows currently)

--- a/source/yt-dlp_gui.py
+++ b/source/yt-dlp_gui.py
@@ -217,36 +217,31 @@ class MainWindow(QWidget):
             del self.app_config["ffmpeg_directory"]
         
         self.set_ffmpeg_directory()
-        self.ffmpeg_directory_display.setText(self.app_config["ffmpeg_directory"])
     
     def click_output_directory_button(self):
         if "output_directory" in self.app_config:
             del self.app_config["output_directory"]
         
         self.set_output_directory()
-        self.output_directory_display.setText(self.app_config["output_directory"])
 
     def set_ffmpeg_directory(self):
-        if "ffmpeg_directory" not in self.app_config:
-            ffmpeg_directory = QFileDialog.getExistingDirectory()
-            self.app_config["ffmpeg_directory"] = ffmpeg_directory
-            self.save_app_config_file()
-        else:
-            print("ffmpeg directory set!")
+        ffmpeg_directory = QFileDialog.getExistingDirectory()
+        self.app_config["ffmpeg_directory"] = ffmpeg_directory
+        self.save_app_config_file()
+        
+        self.ffmpeg_directory_display.setText(self.app_config["ffmpeg_directory"])
 
         if DEBUG:
             self.output_check_text.appendPlainText(
                 f"ffmpeg directory - {self.app_config['ffmpeg_directory']}"
             )
 
-
     def set_output_directory(self):
-        if "output_directory" not in self.app_config:
-            output_directory = QFileDialog.getExistingDirectory()
-            self.app_config["output_directory"] = output_directory
-            self.save_app_config_file()
-        else:
-            print("output directory set!")
+        output_directory = QFileDialog.getExistingDirectory()
+        self.app_config["output_directory"] = output_directory
+        self.save_app_config_file()
+
+        self.output_directory_display.setText(self.app_config["output_directory"])
         
         if DEBUG:
             self.output_check_text.appendPlainText(
@@ -341,17 +336,17 @@ class MainWindow(QWidget):
         if "ffmpeg_directory" not in self.app_config:
             ffmpeg_popup = QMessageBox()
             ffmpeg_popup.setText(
-                "Please select your ffmpeg executable"
+                "Please select the directory containing your ffmpeg executable"
             )
             ffmpeg_popup.exec()
-        self.set_ffmpeg_directory()
+            self.set_ffmpeg_directory()
         
         # Set output directory
         if "output_directory" not in self.app_config:
             output_directory_popup = QMessageBox()
             output_directory_popup.setText("Please set an output directory")
             output_directory_popup.exec()
-        self.set_output_directory()
+            self.set_output_directory()
 
         self.parse_urls()
 

--- a/source/yt-dlp_gui.py
+++ b/source/yt-dlp_gui.py
@@ -344,14 +344,14 @@ class MainWindow(QWidget):
                 "Please select your ffmpeg executable"
             )
             ffmpeg_popup.exec()
-        self.set_ffmpeg_directory(trigger_popup=True, clear_config=False)
+        self.set_ffmpeg_directory()
         
         # Set output directory
         if "output_directory" not in self.app_config:
             output_directory_popup = QMessageBox()
             output_directory_popup.setText("Please set an output directory")
             output_directory_popup.exec()
-        self.set_output_directory(trigger_popup=True, clear_config=False)
+        self.set_output_directory()
 
         self.parse_urls()
 

--- a/source/yt-dlp_gui.py
+++ b/source/yt-dlp_gui.py
@@ -24,7 +24,7 @@ from PyQt6.QtWidgets import (
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import MEDIA_EXTENSIONS
 
-DEBUG = True
+DEBUG = False
 
 
 class MainWindow(QWidget):

--- a/source/yt-dlp_gui.py
+++ b/source/yt-dlp_gui.py
@@ -1,6 +1,7 @@
 import json
 import sys
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QApplication,
     QButtonGroup,
@@ -16,6 +17,7 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QRadioButton,
     QSpacerItem,
+    QTabWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -83,7 +85,7 @@ class MainWindow(QWidget):
 
         # General options widgets
         self.general_options_box = (QGroupBox("General Options"))
-        self.cookies_check_box = QCheckBox("Use Cookies from Browser")
+        self.cookies_check_box = QCheckBox("Use browser cookies")
         self.cookies_browser_dropdown = QComboBox()
 
         # Would prefer a list maintained by yt-dlp, similar to ffmpeg codecs
@@ -94,9 +96,11 @@ class MainWindow(QWidget):
             "Use cookies from your browser. Useful for retrieving membership-gated content on YouTube."
         )
 
+        # QGridLayout: (widget, row, col, row_span, col_span, alignment)
         general_options_box_layout = QGridLayout()
-        general_options_box_layout.addWidget(self.cookies_check_box, 0, 0)
-        general_options_box_layout.addWidget(self.cookies_browser_dropdown, 0, 1)
+        general_options_box_layout.addWidget(self.cookies_check_box, 0, 0, alignment = Qt.AlignmentFlag(0x0001))
+        general_options_box_layout.addWidget(self.cookies_browser_dropdown, 0, 1, alignment = Qt.AlignmentFlag(0x0001))
+        general_options_box_layout.addItem(QSpacerItem(0, 0), 0, 2, 0, 5)
         self.general_options_box.setLayout(general_options_box_layout)
 
 
@@ -117,10 +121,11 @@ class MainWindow(QWidget):
         )
 
         video_box_layout = QGridLayout()
-        video_box_layout.addWidget(self.video_convert_checkbox, 0, 0)
-        video_box_layout.addWidget(self.video_format_dropdown, 0, 1)
-        video_box_layout.addWidget(self.video_quality_label, 1, 0)
-        video_box_layout.addWidget(self.video_quality_dropdown, 1, 1)
+        video_box_layout.addWidget(self.video_quality_label, 0, 0, alignment = Qt.AlignmentFlag(0x0001))
+        video_box_layout.addWidget(self.video_quality_dropdown, 0, 1, alignment = Qt.AlignmentFlag(0x0001))
+        video_box_layout.addWidget(self.video_convert_checkbox, 1, 0, alignment = Qt.AlignmentFlag(0x0001))
+        video_box_layout.addWidget(self.video_format_dropdown, 1, 1, alignment = Qt.AlignmentFlag(0x0001))
+        video_box_layout.addItem(QSpacerItem(0, 0), 0, 2, 2, 5)
         self.video_options_box.setLayout(video_box_layout)
 
 
@@ -137,10 +142,12 @@ class MainWindow(QWidget):
         self.strip_audio_checkbox.setToolTip("Saves only the audio, deletes the video")
 
         audio_box_layout = QGridLayout()
-        audio_box_layout.addWidget(self.strip_audio_checkbox, 0, 0)
-        audio_box_layout.addWidget(self.audio_format_dropdown, 0, 1)
-        audio_box_layout.addWidget(self.audio_bitrate_checkbox, 1, 0)
-        audio_box_layout.addWidget(self.audio_bitrate_input, 1, 1)
+        audio_box_layout.addWidget(self.strip_audio_checkbox, 0, 0, alignment = Qt.AlignmentFlag(0x0001))
+        audio_box_layout.addWidget(self.audio_format_dropdown, 0, 1, alignment = Qt.AlignmentFlag(0x0001))
+        audio_box_layout.addWidget(self.audio_bitrate_checkbox, 1, 0, alignment = Qt.AlignmentFlag(0x0001))
+        audio_box_layout.addWidget(self.audio_bitrate_input, 1, 1, alignment = Qt.AlignmentFlag(0x0001))
+        audio_box_layout.addItem(QSpacerItem(0, 0), 0, 2, 2, 5)
+
         self.audio_options_box.setLayout(audio_box_layout)
 
 
@@ -159,19 +166,18 @@ class MainWindow(QWidget):
         self.output_check_text.setReadOnly(True)
 
 
-        # (widget, row, col, row_span, col_span, alignment)
-        all_options_layout = QGridLayout()  
-        all_options_layout.setColumnMinimumWidth(1, 15) # Add blank space
-        all_options_layout.setRowMinimumHeight(4, 15)
-        all_options_layout.addWidget(self.thumbnail_radio_box, 0, 0, 4, 1)
-        all_options_layout.addWidget(self.general_options_box, 0, 2, 4, 1)
-        all_options_layout.addWidget(self.video_options_box, 5, 0, 4, 1)
-        all_options_layout.addWidget(self.audio_options_box, 5, 2, 4, 1)
+        # Assemble tab bar
+        self.settings_tab_bar = QTabWidget()
+        self.settings_tab_bar.addTab(self.general_options_box, "General")
+        self.settings_tab_bar.addTab(self.thumbnail_radio_box, "Thumbnail")
+        self.settings_tab_bar.addTab(self.video_options_box, "Video")
+        self.settings_tab_bar.addTab(self.audio_options_box, "Audio")
+
 
         # Widgets - assemble main window
         main_layout.addWidget(self.url_input_label)
         main_layout.addWidget(self.url_input)
-        main_layout.addLayout(all_options_layout)
+        main_layout.addWidget(self.settings_tab_bar)
         main_layout.addItem(QSpacerItem(default_width, 60))
         main_layout.addWidget(self.confirm_button)
 


### PR DESCRIPTION
- Organizes the various user options into tabs
- Adds the ability to set your ffmpeg and output directories prior to clicking the download button (also gets rid of the logic that forces you to select your ffmpeg directory when not detected in the app_config file).